### PR TITLE
Adding sender's name to FromEmailAddress

### DIFF
--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -232,7 +232,12 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
      */
     private function addSesHeaders(&$payload, MauticMessage &$sentMessage): void
     {
-        $payload['FromEmailAddress'] = $sentMessage->getFrom()[0]->getAddress();
+        $fromAddress = $sentMessage->getFrom()[0];
+        $name = trim($fromAddress->getName());
+        $payload['FromEmailAddress'] = $name !== ''
+            ? "$name <{$fromAddress->getAddress()}>"
+            : $fromAddress->getAddress();
+
         $payload['ReplyToAddresses'] = $this->stringifyAddresses($sentMessage->getReplyTo());
 
         foreach ($sentMessage->getHeaders()->all() as $header) {


### PR DESCRIPTION
This pull request updates the email sending logic to include the sender's name alongside their email address in the `FromEmailAddress` field when sending emails. Previously, only the email address was used. Now, if the sender's name is available, it will be formatted as "Name <email>".

**Example:**

Before: `johndoe@example.com`
After: `John Doe <johndoe@example.com>`