### PR TITLE
The max that SES can handle is 50 addresses per API Call

### DIFF
--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -325,6 +325,6 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
 
     public function getMaxBatchLimit(): int
     {
-        return 5000;
+        return 50;
     }
 }


### PR DESCRIPTION
When you make the batch 5000 addresses, this will make most accounts break the API sending limit, I suggest you make it 50