### PR TITLE
Add support for SES region eu-north-1

### DIFF
--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -54,6 +54,7 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
         'eu-central-1'   => 'eu-central-1',
         'eu-west-1'      => 'eu-west-1',
         'eu-west-2'      => 'eu-west-2',
+        'eu-north-1'     => 'eu-north-1',
         'sa-east-1'      => 'sa-east-1',
         'us-gov-west-1'  => 'us-gov-west-1',
     ];

--- a/README.MD
+++ b/README.MD
@@ -77,6 +77,7 @@ ca-central-1
 eu-central-1
 eu-west-1
 eu-west-2
+eu-north-1
 sa-east-1
 us-gov-west-1
 ```

--- a/Translations/en_US/validators.ini
+++ b/Translations/en_US/validators.ini
@@ -1,5 +1,5 @@
 mautic.amazonses.plugin.region.empty="Amazon SES region is empty: Add 'region' as a option with a valid Amazon SES region"
-mautic.amazonses.plugin.region.invalid="Amazon SES region is invalid: Choose one of the valid Amazon SES regions: us-east-1, us-east-2, us-west-2 ,ap-south-1, ap-northeast-2,ap-southeast-1,ap-southeast-2,ap-northeast-1,ca-central-1,eu-central-1,eu-west-1,eu-west-2,sa-east-1,us-gov-west-1"
+mautic.amazonses.plugin.region.invalid="Amazon SES region is invalid: Choose one of the valid Amazon SES regions: us-east-1, us-east-2, us-west-2 ,ap-south-1, ap-northeast-2,ap-southeast-1,ap-southeast-2,ap-northeast-1,ca-central-1,eu-central-1,eu-west-1,eu-west-2,eu-north-1,sa-east-1,us-gov-west-1"
 mautic.amazonses.plugin.ratelimit.invalid="Ratelimit must be a numeric value"
 mautic.amazonses.plugin.user.empty="User is not set"
 mautic.amazonses.plugin.password.empty="Password is not set"


### PR DESCRIPTION
This PR fixes #10 by adding support for SES region `eu-north-1` (Stockholm).