### PR TITLE
Based on Issue - #46 Add Bounces to Email Statistics

### DIFF
--- a/EventSubscriber/CallbackSubscriber.php
+++ b/EventSubscriber/CallbackSubscriber.php
@@ -259,15 +259,15 @@ class CallbackSubscriber implements EventSubscriberInterface
             $typeName = 'SOFT';
             $channel = 'AWS';
         }
-
+        $emailId = $this->getEmailHeader($payload);
         $bouncedRecipients = $payload['bounce']['bouncedRecipients'];
-
         foreach ($bouncedRecipients as $bouncedRecipient) {
             $bounceSubType = $payload['bounce']['bounceSubType'];
             $bounceDiagnostic = array_key_exists('diagnosticCode', $bouncedRecipient) ? $bouncedRecipient['diagnosticCode'] : 'unknown';
             $bounceCode = $typeName.': AWS: '.$bounceSubType.': '.$bounceDiagnostic;
-            $this->addFailureByAddress($this->cleanupEmailAddress($bouncedRecipient['emailAddress']), $bounceCode, DoNotContact::BOUNCED, $channel);
-            $this->logger->debug("Mark email '".$bouncedRecipient['emailAddress']."' as bounced, reason: ".$bounceCode);
+            $channelWithId = [$channel => $emailId];
+            $this->addFailureByAddress($this->cleanupEmailAddress($bouncedRecipient['emailAddress']),$bounceCode,DoNotContact::BOUNCED,$channelWithId);
+            $this->logger->debug("Mark email '" . $bouncedRecipient['emailAddress'] . "' as bounced, reason: " . $bounceCode);
         }
     }
 


### PR DESCRIPTION
### Issue #46 

We need to include the channel_id so bounces are marked correctly in the statistics of the mail. 

The structure needs to be like this:
[$channel => $emailId]

According to the mautic documentation here: https://github.com/mautic/mautic/blob/0e6cc523fd5ffb6c86e0529803d9b9f3136ea392/app/bundles/LeadBundle/Model/DoNotContact.php#L57

### How to test:

1. Add the following mails to test segment:

- bounce@simulator.amazonses.com 
- ooto@simulator.amazonses.com 
- complaint@simulator.amazonses.com	

2. Send test mail to test segment
3. Check DB entries in lead_donotcontact

![Bildschirmfoto 2025-03-17 um 11 56 43](https://github.com/user-attachments/assets/a9c7a574-e19e-4c89-8f19-254d014ca2bf)


### Only Hard Bounce is shown in statistics:

![Bildschirmfoto 2025-03-17 um 11 59 45](https://github.com/user-attachments/assets/98b753cb-f911-4bfd-baf8-1f0c5cffbffc)
