### PR TITLE
Update AmazonSesTransportFactory.php

### DIFF
--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -196,6 +196,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
                 'version'     => 'latest',
                 'credentials' => CredentialProvider::fromCredentials(new Credentials($dsn_user, $dsn_password)),
                 'region'      => $dsn_region,
+                'use_aws_shared_config_files' => false,
             ];
 
             if ($handler) {


### PR DESCRIPTION
Adding 'use_aws_shared_config_files' => false tells the AWS SDK not to look for:
	•	~/.aws/credentials
	•	~/.aws/config