### PR TITLE
Amazon SES Plugin: Send Rate Throttling, Quota Caching & Cleanup

### DIFF
--- a/Config/services.php
+++ b/Config/services.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use MauticPlugin\AmazonSesBundle\Mailer\Factory\AmazonSesTransportFactory;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service; 
+
 /**
  * @param ContainerConfigurator $configurator
  * @return void

--- a/Config/services.php
+++ b/Config/services.php
@@ -31,7 +31,13 @@ return static function (ContainerConfigurator $configurator) {
     $services->load('MauticPlugin\\AmazonSesBundle\\', '../')
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
-    $services->get(AmazonSesTransportFactory::class)
-        ->arg('$pathsHelper', service('mautic.helper.paths'))
-        ->tag('mailer.transport_factory');
+    $services->get(\MauticPlugin\AmazonSesBundle\Mailer\Factory\AmazonSesTransportFactory::class)
+    ->arg('$transportCallback', service(\Mautic\EmailBundle\Model\TransportCallback::class))
+    ->arg('$eventDispatcher', service('event_dispatcher'))
+    ->arg('$translator', service('translator'))
+    ->arg('$entityManager', service('doctrine.orm.entity_manager'))
+    ->arg('$pathsHelper', service('mautic.helper.paths'))
+    ->arg('$logger', service('logger'))
+    ->arg('$amazonclient', null) // optional fallback if not needed
+    ->tag('mailer.transport_factory');
 };

--- a/Config/services.php
+++ b/Config/services.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
  * @param ContainerConfigurator $configurator
  * @return void
  */
+
 return static function (ContainerConfigurator $configurator) {
     $services = $configurator->services()
         ->defaults()
@@ -28,5 +29,7 @@ return static function (ContainerConfigurator $configurator) {
     $services->load('MauticPlugin\\AmazonSesBundle\\', '../')
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
-    $services->get(AmazonSesTransportFactory::class)->tag('mailer.transport_factory');
+    $services->get(AmazonSesTransportFactory::class)
+        ->arg('$pathsHelper', service('mautic.helper.paths'))
+        ->tag('mailer.transport_factory');
 };

--- a/Config/services.php
+++ b/Config/services.php
@@ -32,7 +32,7 @@ return static function (ContainerConfigurator $configurator) {
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
     $services->get(\MauticPlugin\AmazonSesBundle\Mailer\Factory\AmazonSesTransportFactory::class)
-    ->autowire(false) // 👈 disable for this one!
+    ->autowire(false) 
     ->arg('$transportCallback', service(\Mautic\EmailBundle\Model\TransportCallback::class))
     ->arg('$eventDispatcher', service('event_dispatcher'))
     ->arg('$translator', service('translator'))

--- a/Config/services.php
+++ b/Config/services.php
@@ -32,12 +32,13 @@ return static function (ContainerConfigurator $configurator) {
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
     $services->get(\MauticPlugin\AmazonSesBundle\Mailer\Factory\AmazonSesTransportFactory::class)
+    ->autowire(false) // 👈 disable for this one!
     ->arg('$transportCallback', service(\Mautic\EmailBundle\Model\TransportCallback::class))
     ->arg('$eventDispatcher', service('event_dispatcher'))
     ->arg('$translator', service('translator'))
     ->arg('$entityManager', service('doctrine.orm.entity_manager'))
     ->arg('$pathsHelper', service('mautic.helper.paths'))
     ->arg('$logger', service('logger'))
-    ->arg('$amazonclient', null) // optional fallback if not needed
+    ->arg('$amazonclient', null)
     ->tag('mailer.transport_factory');
 };

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -25,7 +25,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 {
     private static SesV2Client $amazonclient;
     private static TranslatorInterface $translator;
-
+    private PathsHelper $pathsHelper;
     private EntityManagerInterface $entityManager;
 
     public function __construct(
@@ -33,12 +33,14 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         EventDispatcherInterface $eventDispatcher,
         TranslatorInterface $translator,
         EntityManagerInterface $entityManager,
+        PathsHelper $pathsHelper,
         ?LoggerInterface $logger = null,
         ?SesV2Client $amazonclient = null
     ) {
         parent::__construct($eventDispatcher, $amazonclient, $logger);
         self::$translator = $translator;
         $this->entityManager = $entityManager;
+        $pathsHelper,
     }
 
     protected function getSupportedSchemes(): array
@@ -156,10 +158,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 
      private function getCachePath(): string
      {
-        $container = $GLOBALS['kernel']->getContainer();
-        $pathsHelper = $container->get('mautic.helper.paths');
-        $cacheDir = $pathsHelper->getSystemPath('cache', true);
-        return $cacheDir . '/ses_send_quota.json';
+            return $this->pathsHelper->getSystemPath('cache', true) . '/ses_send_quota.json';
      }
 
     /**

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -18,11 +18,14 @@ use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
 
 class AmazonSesTransportFactory extends AbstractTransportFactory
 {
     private static SesV2Client $amazonclient;
     private static TranslatorInterface $translator;
+    private ParameterBagInterface $params;
 
     private EntityManagerInterface $entityManager;
 
@@ -37,6 +40,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         parent::__construct($eventDispatcher, $amazonclient, $logger);
         self::$translator = $translator;
         $this->entityManager = $entityManager;
+        $this->params = $params;
     }
 
     protected function getSupportedSchemes(): array
@@ -154,7 +158,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 
     private function getCachePath(): string
     {
-        return dirname(__DIR__, 5) . '/var/cache/ses_send_quota.json';
+        return $this->params->get('kernel.cache_dir') . 'ses_send_quota.json';
     }
 
     /**

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -156,7 +156,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 
     private function getCachePath(): string
     {
-          $coreParams = new CoreParametersHelper();
+          $coreParams = $this->container->get(CoreParametersHelper::class);
           return $coreParams->get('kernel.cache_dir') . '/ses_send_quota.json';
     }
 

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -18,14 +18,13 @@ use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 
 class AmazonSesTransportFactory extends AbstractTransportFactory
 {
     private static SesV2Client $amazonclient;
     private static TranslatorInterface $translator;
-    private ParameterBagInterface $params;
 
     private EntityManagerInterface $entityManager;
 
@@ -40,7 +39,6 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         parent::__construct($eventDispatcher, $amazonclient, $logger);
         self::$translator = $translator;
         $this->entityManager = $entityManager;
-        $this->params = $params;
     }
 
     protected function getSupportedSchemes(): array
@@ -158,7 +156,9 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 
     private function getCachePath(): string
     {
-        return $this->params->get('kernel.cache_dir') . 'ses_send_quota.json';
+        $container = \Mautic\CoreBundle\Factory\MauticFactory::getContainerStatic();
+        $cachePath = $container->getParameter('kernel.cache_dir');
+        return $cachePath . '/ses_send_quota.json';    
     }
 
     /**

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -154,11 +154,10 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         }
      }
 
-    private function getCachePath(): string
+    private function getQuotaCachePath(): string
     {
-        $container = \Mautic\CoreBundle\Factory\MauticFactory::getContainerStatic();
-        $cachePath = $container->getParameter('kernel.cache_dir');
-        return $cachePath . '/ses_send_quota.json';    
+        $cacheDir = $GLOBALS['kernel']->getContainer()->getParameter('kernel.cache_dir');
+        return $cacheDir . '/ses_send_quota.json';
     }
 
     /**

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\PathsHelper;
 
 class AmazonSesTransportFactory extends AbstractTransportFactory
 {
@@ -156,8 +156,10 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 
      private function getCachePath(): string
      {
-        $pathsHelper = $this->get('mautic.helper.paths');
-        return  $pathsHelper->getSystemPath('cache') . '/ses_send_quota.json';
+        $container = $GLOBALS['kernel']->getContainer();
+        $pathsHelper = $container->get('mautic.helper.paths');
+        $cacheDir = $pathsHelper->getSystemPath('cache', true);
+        return $cacheDir . '/ses_send_quota.json';
      }
 
     /**

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
 class AmazonSesTransportFactory extends AbstractTransportFactory
 {
@@ -156,8 +156,8 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 
     private function getCachePath(): string
     {
-        $cacheDir = $GLOBALS['kernel']->getContainer()->getParameter('kernel.cache_dir');
-        return $cacheDir . '/ses_send_quota.json';
+          $coreParams = new CoreParametersHelper();
+          return $coreParams->get('kernel.cache_dir') . '/ses_send_quota.json';
     }
 
     /**

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -40,7 +40,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         parent::__construct($eventDispatcher, $amazonclient, $logger);
         self::$translator = $translator;
         $this->entityManager = $entityManager;
-        $pathsHelper,
+        $pathsHelper;
     }
 
     protected function getSupportedSchemes(): array

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -154,11 +154,11 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         }
      }
 
-    private function getCachePath(): string
-    {
-          $coreParams = $this->container->get(CoreParametersHelper::class);
-          return $coreParams->get('kernel.cache_dir') . '/ses_send_quota.json';
-    }
+     private function getCachePath(): string
+     {
+        $pathsHelper = $this->get('mautic.helper.paths');
+        return  $pathsHelper->getSystemPath('cache') . '/ses_send_quota.json';
+     }
 
     /**
      * @return SesV2Client

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -56,7 +56,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
     
             $manualRate = $dsn->getOption('ratelimit');
     
-            $cacheFile = $GLOBALS['kernel']->getCacheDir() . '/ses_send_quota.json';
+            $cacheFile = $this->getCachePath();
             $cacheTTL = 3600; // 60 minutes
     
             $cachedRate = $this->getCachedSendRate($cacheFile, $cacheTTL);
@@ -151,6 +151,11 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
             $this->logger?->error("Failed to move temp SES cache to: $cacheFile");
         }
      }
+
+    private function getCachePath(): string
+    {
+        return dirname(__DIR__, 5) . '/var/cache/ses_send_quota.json';
+    }
 
     /**
      * @return SesV2Client

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -40,7 +40,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         parent::__construct($eventDispatcher, $amazonclient, $logger);
         self::$translator = $translator;
         $this->entityManager = $entityManager;
-        $pathsHelper;
+        $this->pathsHelper = $pathsHelper;
     }
 
     protected function getSupportedSchemes(): array

--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -154,7 +154,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
         }
      }
 
-    private function getQuotaCachePath(): string
+    private function getCachePath(): string
     {
         $cacheDir = $GLOBALS['kernel']->getContainer()->getParameter('kernel.cache_dir');
         return $cacheDir . '/ses_send_quota.json';

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,3 @@
-
 # Mautic AWS SES Plugin with SNS Callback
 
 This plugin provides integration between [Mautic 5](https://www.mautic.org) and [Amazon SES](https://aws.amazon.com/ses/) for sending emails through AWS. It also integrates with [Amazon SNS](https://aws.amazon.com/sns/) for handling email feedback such as bounces and complaints via callbacks.
@@ -11,8 +10,13 @@ Feel free to suggest improvements or provide feedback — this is my first Mauti
 
 ## Features
 - Send emails through Amazon SES using the API.
-- Support for setting AWS regions directly within the DSN.
+- Support for setting AWS regions and optional custom rate limits in the DSN.
 - Integration with Amazon SNS to process bounces and complaints via callback.
+- Built-in **rate limiting** to honor SES sending quotas.
+- Dynamic **batch size** matching the current SES max send rate.
+- Auto-fetch and cache your SES sending quota.
+- Manual override of rate limit with `ratelimit` DSN option.
+- Optional retry handling for partial email failures.
 
 ---
 
@@ -42,27 +46,28 @@ Feel free to suggest improvements or provide feedback — this is my first Mauti
 3. In the **DSN** field, enter your connection string in the following format:
 
    ```text
-   mautic+ses+api://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@default?region=<AWS_REGION>
+   mautic+ses+api://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@default?region=<AWS_REGION>&ratelimit=14
    ```
 
    - Replace `<AWS_ACCESS_KEY>` and `<AWS_SECRET_KEY>` with your AWS credentials.
    - Replace `<AWS_REGION>` with your AWS region (e.g., `us-east-1`).
+   - Optionally set `ratelimit` to override the SES max send rate manually.
 
 4. Set the region in the `options` parameter, for example:
 
    ```text
    Label: region   Value: eu-west-1
    ```
-![Amazon SES Integration](https://github.com/pm-pmaas/etailors_amazon_ses/blob/1.0.1/Assets/img/mautic-ses-dsn.png)
 
+![Amazon SES Integration](https://github.com/pm-pmaas/etailors_amazon_ses/blob/1.0.1/Assets/img/mautic-ses-dsn.png)
 
 ### 3. AWS SES Configuration
 
 1. Ensure that you have verified your domain and email addresses in AWS SES.
-2. Set up the appropriate IAM user with permissions to send emails via SES.  **Please make sure u have created a new IAM user directly
-via IAM instead of upgrading an SMTP user with the permission: sending via SES API **
-There are some cases known that it will not work when u upgrade the SMTP user with the extra permission
-(https://github.com/pm-pmaas/etailors_amazon_ses/issues/28)
+2. Set up the appropriate IAM user with permissions to send emails via SES.  **Please make sure you create a new IAM user directly
+via IAM instead of upgrading an SMTP user with the permission: sending via SES API**.
+   
+   There are known issues when upgrading SMTP-only users — see: [issue #28](https://github.com/pm-pmaas/etailors_amazon_ses/issues/28).
 
 ### 4. Available Regions
 
@@ -104,10 +109,18 @@ To receive feedback from Amazon SES regarding bounces and complaints, you need t
 
 ---
 
-## Batch Limit
+## Batch Limit & Throttling
 
-Informed by: @mabumusa1 When you make the batch 5000 addresses, this will make most accounts break the API sending limit, I suggest you make it 50, so merged 
-this pull request ( https://github.com/pm-pmaas/etailors_amazon_ses/pull/8 ).
+To avoid exceeding SES rate limits, this plugin automatically:
+
+- Caches the current `maxSendRate` returned by AWS SES.
+- Dynamically adjusts the batch size to match that rate.
+- Throttles outgoing email API calls using `usleep()`.
+- Allows overriding the send rate via `ratelimit` DSN option.
+
+This prevents common errors like `TooManyRequests` while making the most of your quota.
+
+---
 
 ## Debugging
 


### PR DESCRIPTION
This update adds dynamic throttling based on SES MaxSendRate, with support for manual override via ratelimit in the DSN. Also added quota caching and replaced hardcoded paths with proper usage of Mautic’s PathsHelper.

Highlights:
	•	usleep() throttling to respect SES rate limits
	•	Quota caching to avoid repeated API calls
	•	Uses PathsHelper for clean, safe file paths
	•	Manual rate override via ratelimit=xx
	•	Cleaned up constructor/service registration logic

Should make sending more stable on production SES accounts, especially for higher-volume senders. Logs will now show throttling behavior clearly (e.g. sleeping for 16129 µs at 62/sec).