### PR TITLE
Fix SES forwarding header typo

### DIFF
--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -284,11 +284,11 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
                 $payload['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
             } else {
                 switch ($header->getName()) {
-                    case 'X-SES-FEEDBACK-FORWARDNG-EMAIL-ADDRESS':
+                    case 'X-SES-FEEDBACK-FORWARDING-EMAIL-ADDRESS':
                         $payload['FeedbackForwardingEmailAddress'] = $header->getBodyAsString();
                         $sentMessage->getHeaders()->remove($header->getName());
                         break;
-                    case 'X-SES-FEEDBACK-FORWARDNG-EMAIL-ADDRESS-IDENTITYARN':
+                    case 'X-SES-FEEDBACK-FORWARDING-EMAIL-ADDRESS-IDENTITYARN':
                         $payload['FeedbackForwardingEmailAddressIdentityArn'] = $header->getBodyAsString();
                         $sentMessage->getHeaders()->remove($header->getName());
                         break;


### PR DESCRIPTION
## Summary
- correct header strings used when adding FeedbackForwarding info

## Testing
- `composer` not installed, so no tests run