### PR TITLE
Fix typo in header comments

### DIFF
--- a/AmazonSesBundle.php
+++ b/AmazonSesBundle.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * @copyright       (c) 2024. e-tailors IP B.V. All rights reserverd
+ * @copyright       (c) 2024. e-tailors IP B.V. All rights reserved
  * @author          Paul Maas <p.maas@e-tailors.com>
  *
  * @link            https://www.e-tailors.com

--- a/Config/config.php
+++ b/Config/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * @copyright       (c) 2024. e-tailors IP B.V. All rights reserverd
+ * @copyright       (c) 2024. e-tailors IP B.V. All rights reserved
  * @author          Paul Maas <p.maas@e-tailors.com>
  *
  * @link            https://www.e-tailors.com

--- a/Config/services.php
+++ b/Config/services.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * @copyright       (c) 2024. e-tailors IP B.V. All rights reserverd
+ * @copyright       (c) 2024. e-tailors IP B.V. All rights reserved
  * @author          Paul Maas <p.maas@e-tailors.com>
  *
  * @link            https://www.e-tailors.com

--- a/DependencyInjection/AmazonSesExtension.php
+++ b/DependencyInjection/AmazonSesExtension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * @copyright       (c) 2024. e-tailors IP B.V. All rights reserverd
+ * @copyright       (c) 2024. e-tailors IP B.V. All rights reserved
  * @author          Paul Maas <p.maas@e-tailors.com>
  *
  * @link            https://www.e-tailors.com

--- a/EventSubscriber/CallbackSubscriber.php
+++ b/EventSubscriber/CallbackSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * @copyright       (c) 2024. e-tailors IP B.V. All rights reserverd
+ * @copyright       (c) 2024. e-tailors IP B.V. All rights reserved
  * @author          Paul Maas <p.maas@e-tailors.com>
  *
  * @link            https://www.e-tailors.com

--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * @copyright       (c) 2024. e-tailors IP B.V. All rights reserverd
+ * @copyright       (c) 2024. e-tailors IP B.V. All rights reserved
  * @author          Paul Maas <p.maas@e-tailors.com>
  *
  * @link            https://www.e-tailors.com


### PR DESCRIPTION
## Summary
- fix spelling of "All rights reserved" in header comments

## Testing
- `composer test` *(fails: command not found)*