### PR TITLE
Fix SNS callback exception type

### DIFF
--- a/EventSubscriber/CallbackSubscriber.php
+++ b/EventSubscriber/CallbackSubscriber.php
@@ -23,6 +23,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Mautic\LeadBundle\Model\DoNotContact as DncModel;
 
@@ -171,7 +172,7 @@ class CallbackSubscriber implements EventSubscriberInterface
                     } else {
                         $reason = 'HTTP Code '.$response->getStatusCode().', '.$response->getContent();
                     }
-                } catch (TransferException $e) {
+                } catch (TransportExceptionInterface $e) {
                     $reason = $e->getMessage();
                 }
 


### PR DESCRIPTION
## Summary
- catch TransportExceptionInterface from Symfony HttpClient

## Testing
- `php -l EventSubscriber/CallbackSubscriber.php` *(fails: `php: command not found`)*