### PR TITLE
fix: getAccount method when no ses:GetAccount action permissions are set

### DIFF
--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -23,6 +23,8 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 
 class AmazonSesTransportFactory extends AbstractTransportFactory
 {
+    const DEFAULT_RATE = 14;
+
     private static SesV2Client $amazonclient;
     private static TranslatorInterface $translator;
     private PathsHelper $pathsHelper;
@@ -71,12 +73,13 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
                     $fetchedRate = (int)floor($account->get('SendQuota')['MaxSendRate']);
                     $this->saveSendRateToCache($cacheFile, $fetchedRate);
                 } catch (\Exception $e) {
+                    $this->saveSendRateToCache($cacheFile, self::DEFAULT_RATE);
                     $this->logger?->error('SES quota fetch failed: ' . $e->getMessage());
                     $fetchedRate = $this->getCachedSendRate($cacheFile, PHP_INT_MAX) ?? null;
                 }
             }
     
-            $effectiveRate = (int)($manualRate ?? $cachedRate ?? $fetchedRate ?? 14);
+            $effectiveRate = (int)($manualRate ?? $cachedRate ?? $fetchedRate ?? self::DEFAULT_RATE);;
     
             return new AmazonSesTransport(
                 $client,


### PR DESCRIPTION
# Fix: Cache fallback rate when GetAccount permission is denied

## Problem
When the provided AWS SES credentials lack the `ses:GetAccount` permission, AmazonSesTransportFactory repeatedly attempts to fetch the send rate quota on every transport creation, resulting in repeated 403 Forbidden errors in logs, like:

```
Aws\SesV2\Exception\SesV2Exception: Error executing "GetAccount" on "https://email.eu-west-1.amazonaws.com/v2/email/account"; AWS HTTP error: Client error: `GET https://email.eu-west-1.amazonaws.com/v2/email/account` resulted in a `403 Forbidden` response: {"Message":"User: arn:aws:iam::REDACTED:user/REDACTED is not authorized to perform: ses:GetAccount on resource: * (truncated...) 
```

This could cause HTTP 429 errors on consecutive calls to AWS endpoints.

## Solution
Modified the exception handling in `create()` method to cache the default fallback rate (14) when `GetAccount` fails. This prevents repeated API calls while maintaining the existing fallback behavior.