### PR TITLE
Document IAM user policy

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -76,7 +76,7 @@ Your IAM user must have permission to send and get account limits. Here's an exa
        "Version": "2012-10-17",
        "Statement": [
            {
-               "Sid": "Allow Sending",
+               "Sid": "AllowSending",
                "Effect": "Allow",
                "Action": [
                    "ses:SendEmail",


### PR DESCRIPTION
Adds an example of the policy that worked for the IAM user I created for sending mail.