### PR TITLE
Update README.MD supported regions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -142,20 +142,23 @@ Your IAM user must have permission to send and get account limits. Here's an exa
 Below are the supported AWS SES regions:
 
 ```
-us-east-1
-us-east-2
-ap-south-1
+af-south-1
+ap-northeast-1
 ap-northeast-2
+ap-south-1
 ap-southeast-1
 ap-southeast-2
-ap-northeast-1
 ca-central-1
 eu-central-1
+eu-north-1
 eu-west-1
 eu-west-2
-eu-north-1
 sa-east-1
+us-east-1
+us-east-2
 us-gov-west-1
+us-west-1
+us-west-2
 ```
 
 ---


### PR DESCRIPTION
I noticed my region (`us-west-2`) wasn't listed, so I updated the list from the `AMAZON_REGION` constant in the transport. Also sorted the list alphabetically.