### PR TITLE
Fix escaping of commas in FromEmailAddress

### DIFF
--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -275,9 +275,13 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
     {
         $fromAddress = $sentMessage->getFrom()[0];
         $name = trim($fromAddress->getName());
-        $payload['FromEmailAddress'] = $name !== ''
-            ? "$name <{$fromAddress->getAddress()}>"
-            : $fromAddress->getAddress();
+
+        if ($name !== '') {
+            $safeName = str_replace('"', '\"', $name);
+            $payload['FromEmailAddress'] = sprintf('"%s" <%s>', $safeName, $fromAddress->getAddress());
+        } else {
+            $payload['FromEmailAddress'] = $fromAddress->getAddress();
+        }
 
         $payload['ReplyToAddresses'] = $this->stringifyAddresses($this->setReplyTo($sentMessage));
 


### PR DESCRIPTION
The current version doesn't sanitize from name.

If there are commas in the from name set through Mautic's Email / Advanced tab, the email fails.
Commas are separators in RFC 5322 address lists, so SES can interpret that as two addresses (Doe and John <john@example.com>), which makes the request invalid and the send fails. The code is manually concatenating the string and never quotes/escapes the display name.

This PR fixes the issue