### PR TITLE
improve: add a more robust handling of special characters in the from name

### DIFF
--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -274,14 +274,10 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
     private function addSesHeaders(&$payload, MauticMessage &$sentMessage, array $mailData): void
     {
         $fromAddress = $sentMessage->getFrom()[0];
-        $name = trim($fromAddress->getName());
-
-        if ($name !== '') {
-            $safeName = str_replace('"', '\"', $name);
-            $payload['FromEmailAddress'] = sprintf('"%s" <%s>', $safeName, $fromAddress->getAddress());
-        } else {
-            $payload['FromEmailAddress'] = $fromAddress->getAddress();
-        }
+        $encodedName = $fromAddress->getEncodedName();
+        $payload['FromEmailAddress'] = $encodedName !== ''
+            ? "$encodedName <{$fromAddress->getEncodedAddress()}>"
+            : $fromAddress->getEncodedAddress();
 
         $payload['ReplyToAddresses'] = $this->stringifyAddresses($this->setReplyTo($sentMessage));
 


### PR DESCRIPTION
The code now uses `getEncodedName()` and `getEncodedAddress()` from **Symfony's** `Address` class, which:

- Properly quotes the display name — Names with commas (or other special characters) are wrapped in quotes, e.g., "NAME, founder of COMPANY" instead of NAME, founder of COMPANY
- Handles IDN encoding — getEncodedAddress() properly encodes internationalized domain names

When AWS SES receives the from address, it will be formatted as:
"NAME, founder of COMPANY" <name@company.ch>