### PR TITLE
Feature - Add shared token bucket rate limiting (multi-worker safe) and fix duplicate sends on partial failure

### DIFF
--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -78,15 +78,17 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
                     $fetchedRate = $this->getCachedSendRate($cacheFile, PHP_INT_MAX) ?? null;
                 }
             }
-    
-            $effectiveRate = (int)($manualRate ?? $cachedRate ?? $fetchedRate ?? self::DEFAULT_RATE);;
-    
+
+            $effectiveRate = (int)($manualRate ?? $cachedRate ?? $fetchedRate ?? self::DEFAULT_RATE);
+            $batchMultiplier = (int)($dsn->getOption('batchmultiplier') ?? 10);
+
             return new AmazonSesTransport(
                 $client,
                 $this->entityManager,
+                $this->pathsHelper,
                 $this->dispatcher,
                 $this->logger,
-                ['maxSendRate' => $effectiveRate]
+                ['maxSendRate' => $effectiveRate, 'batchMultiplier' => $batchMultiplier]
             );
         }
 

--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -324,38 +324,19 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
      */
     private function processFailures(array $failures): void
     {
-        $this->logger->debug('proces failures:');
-        $this->logger->debug(json_encode($failures));
-
         if (empty($failures)) {
             return;
         }
-        // Make a copy of the metadata
-        $metadata = $this->getMetadata();
-        $keys     = array_keys($metadata);
 
-        // Clear the metadata
-        $this->message->clearMetadata();
-
-        // Add the metadata for the failed recipients
-
-        if (!empty($metadata)) {
-            foreach ($failures as $failure) {
-                if (is_int($failure)) {
-                    $this->message->addMetadata($keys[$failure], $metadata[$keys[$failure]]);
-                } else {
-                    $this->message->addMetadata($failure, $metadata[$failure]);
-                }
-            }
-        }
-
-        $this->logger->debug('There are partial failures, replacing metadata, and failing the message');
-        /*
-            The message that failed will be retried with only the failed recipients
-            This transport assume that the queue mode is enabled
-        */
-
-        throw new \Exception('There are  '.count($failures).' partial failures, check logs for exception reasons');
+        // Log failures but do NOT throw. Throwing causes Symfony Messenger to retry
+        // the ENTIRE message with ALL recipients (metadata modifications are lost during
+        // re-serialization), resulting in duplicate sends. Failed recipients were already
+        // retried inline in doSend() with exponential backoff.
+        $this->logger->error(sprintf(
+            '%d recipients failed after inline retry: %s',
+            count($failures),
+            implode(', ', $failures)
+        ));
     }
 
     /**

--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -30,6 +30,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Mautic\EmailBundle\Entity\Email as MauticEmailEntity;
 use Doctrine\ORM\EntityManagerInterface;
+use Mautic\CoreBundle\Helper\PathsHelper;
 use Symfony\Component\Mailer\Envelope;
 
 class AmazonSesTransport extends AbstractTransport implements TokenTransportInterface
@@ -86,6 +87,7 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
 
     private $enableTemplate;
     private $entityManager;
+    private PathsHelper $pathsHelper;
     private MauticMessage $message;
     private Envelope $envelope;
 
@@ -98,6 +100,7 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
     public function __construct(
         SesV2Client $amazonclient,
         EntityManagerInterface $entityManager,
+        PathsHelper $pathsHelper,
         ?EventDispatcherInterface $dispatcher = null,
         ?LoggerInterface $logger = null,
         $settings = [],
@@ -107,6 +110,7 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
         $this->client     = $amazonclient;
         $this->dispatcher = $dispatcher;
         $this->entityManager = $entityManager;
+        $this->pathsHelper = $pathsHelper;
         $this->settings   = $settings;
 
         /*
@@ -140,7 +144,6 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
         try {
             $email = $message->getOriginalMessage();
 
-
             // Ensure the message is an instance of MauticMessage
             if (!$email instanceof MauticMessage) {
                 throw new \Exception('Message must be an instance of '.MauticMessage::class);
@@ -164,25 +167,89 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
                     $commands[] = $this->client->getCommand('sendEmail', $payload);
                 }
 
-                $pool = new CommandPool($this->client, $commands, [
-                    'concurrency' => $this->settings['maxSendRate'],
-                    'fulfilled' => function (Result $result, $iteratorId) {
-                        // Log fulfilled messages if necessary
-                    },
-                    'rejected' => function (AwsException $reason, $iteratorId) use ($commands, &$failures) {
-                        $data = $commands[$iteratorId]->toArray();
-                        $failed = Address::create($data['Destination']['ToAddresses'][0]);
-                        $failures[] = $failed->getAddress();
+                // Send in micro-batches with shared token bucket for cross-worker rate limiting.
+                // Lock held only ~30µs (file read/write), NOT during API call.
+                // Workers send in parallel — the bucket ensures combined rate across
+                // all workers never exceeds the SES limit. Set ratelimit to the full
+                // SES account limit (e.g. 70) regardless of worker count.
+                $rate = max(1, (int) ($this->settings['maxSendRate'] ?? 14));
+                $microBatchSize = max(1, (int) ceil($rate / 10));
+                $batches = array_chunk($commands, $microBatchSize);
+                $bucketFile = $this->pathsHelper->getSystemPath('cache', true) . '/ses_token_bucket.json';
 
-                        // Log detailed failure reasons
-                        $this->logger->error('Rejected: message to '.implode(',', $data['Destination']['ToAddresses']));
-                        $this->logger->error('AWS SES Error: '.$reason->getMessage());
-                        $this->logger->error('Payload: '.json_encode($data));
-                    },
-                ]);
+                foreach ($batches as $bi => $batchCommands) {
+                    $batchFailures = [];
 
-                $promise = $pool->promise();
-                $promise->wait();
+                    // Acquire tokens — brief lock (~30µs), then send with NO lock held
+                    $this->acquireTokens($bucketFile, count($batchCommands), $rate);
+
+                    $pool = new CommandPool($this->client, $batchCommands, [
+                        'concurrency' => count($batchCommands),
+                        'fulfilled' => function (Result $result, $iteratorId) {
+                        },
+                        'rejected' => function (AwsException $reason, $iteratorId) use ($batchCommands, &$batchFailures) {
+                            $batchFailures[] = $batchCommands[$iteratorId];
+                            $data = $batchCommands[$iteratorId]->toArray();
+                            $this->logger->error('Rejected: message to '.implode(',', $data['Destination']['ToAddresses']));
+                            $this->logger->error('AWS SES Error: '.$reason->getMessage());
+                        },
+                    ]);
+
+                    $promise = $pool->promise();
+                    $promise->wait();
+
+                    // Inline retry for transient SES failures (network glitch, 429, etc.)
+                    if (!empty($batchFailures)) {
+                        $initialFailCount = count($batchFailures);
+                        $retryDelay = 1000000;
+                        for ($attempt = 1; $attempt <= 3 && !empty($batchFailures); $attempt++) {
+                            $this->logger->error(sprintf(
+                                '%d SES sends failed, inline retry %d/3 after %dms',
+                                count($batchFailures), $attempt, $retryDelay / 1000
+                            ));
+                            usleep($retryDelay);
+                            $retryDelay *= 2;
+
+                            $retryCommands = $batchFailures;
+                            $batchFailures = [];
+                            $retryPool = new CommandPool($this->client, $retryCommands, [
+                                'concurrency' => count($retryCommands),
+                                'fulfilled' => function (Result $result, $iteratorId) {
+                                },
+                                'rejected' => function (AwsException $reason, $iteratorId) use ($retryCommands, &$batchFailures) {
+                                    $batchFailures[] = $retryCommands[$iteratorId];
+                                    $data = $retryCommands[$iteratorId]->toArray();
+                                    $this->logger->error(sprintf(
+                                        'Retry rejected: %s — %s',
+                                        $data['Destination']['ToAddresses'][0],
+                                        $reason->getAwsErrorMessage() ?: $reason->getMessage()
+                                    ));
+                                },
+                            ]);
+                            $retryPool->promise()->wait();
+
+                            if (empty($batchFailures)) {
+                                $this->logger->error(sprintf(
+                                    'All %d recovered on retry %d/3',
+                                    count($retryCommands), $attempt
+                                ));
+                                break;
+                            }
+                        }
+
+                        $recovered = $initialFailCount - count($batchFailures);
+                        if ($recovered > 0) {
+                            $this->logger->error(sprintf(
+                                '%d/%d recovered by inline retry, %d permanently failed',
+                                $recovered, $initialFailCount, count($batchFailures)
+                            ));
+                        }
+                        foreach ($batchFailures as $failedCmd) {
+                            $data = $failedCmd->toArray();
+                            $failures[] = $data['Destination']['ToAddresses'][0];
+                        }
+                    }
+                }
             }
 
             $this->processFailures($failures);
@@ -227,7 +294,6 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
             ];
             yield $payload;
             $payload = [];
-            $this->throttle();
 
         } else {
 
@@ -262,7 +328,6 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
                 ];
                 yield $payload;
                 $payload = [];
-                $this->throttle();
             }
         }
     }
@@ -354,31 +419,60 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
 
     public function getMaxBatchLimit(): int
     {
-        return (int) ($this->settings['maxSendRate'] ?? 14);    
+        // High batch limit so each Messenger message has many contacts.
+        // Actual send rate is controlled by micro-batch pacing in doSend().
+        $rate = (int) ($this->settings['maxSendRate'] ?? 14);
+        $multiplier = (int) ($this->settings['batchMultiplier'] ?? 10);
+        return $rate * $multiplier;
     }
 
-    private function throttle(): void
+    /**
+     * Acquire tokens from a shared file-based token bucket.
+     * Lock is held only during file read/write (~30µs), NOT during API calls.
+     * Workers sleep outside the lock when tokens are unavailable.
+     */
+    private function acquireTokens(string $bucketFile, int $tokens, int $rate): void
     {
-        static $lastSendTime = 0;
-        
-        $rate = $this->settings['maxSendRate'] ?? 14;
-        $targetInterval = (int)(1_000_000 / max(1, $rate));
-        
-        $now = microtime(true) * 1_000_000;
-        
-        if ($lastSendTime > 0) {
-            $elapsed = $now - $lastSendTime;
-            $remainingDelay = $targetInterval - $elapsed;
-            
-            if ($remainingDelay > 1000) {
-                usleep((int)$remainingDelay);
-                $this->logger?->debug("SES adaptive throttling: elapsed={$elapsed}µs, sleeping={$remainingDelay}µs");
-            } else {
-                $this->logger?->debug("SES adaptive throttling: no sleep needed (elapsed={$elapsed}µs)");
+        while (true) {
+            $fh = fopen($bucketFile, 'c+');
+            flock($fh, LOCK_EX);
+
+            $data = fread($fh, 256);
+            $bucket = $data ? json_decode($data, true) : null;
+            $now = microtime(true);
+
+            if (!$bucket || !isset($bucket['tokens'], $bucket['last_time'])) {
+                $bucket = ['tokens' => 0.0, 'last_time' => $now];
             }
+
+            // Refill tokens based on elapsed time, cap at rate
+            $elapsed = $now - $bucket['last_time'];
+            $bucket['tokens'] = min((float) $rate, $bucket['tokens'] + $elapsed * $rate);
+            $bucket['last_time'] = $now;
+
+            if ($bucket['tokens'] >= $tokens) {
+                $bucket['tokens'] -= $tokens;
+                ftruncate($fh, 0);
+                rewind($fh);
+                fwrite($fh, json_encode($bucket));
+                flock($fh, LOCK_UN);
+                fclose($fh);
+                return;
+            }
+
+            // Not enough tokens — save current state so next iteration sees elapsed time,
+            // then release lock and sleep outside
+            $deficit = $tokens - $bucket['tokens'];
+            $waitUs = (int) ceil(($deficit / $rate) * 1_000_000);
+
+            ftruncate($fh, 0);
+            rewind($fh);
+            fwrite($fh, json_encode($bucket));
+            flock($fh, LOCK_UN);
+            fclose($fh);
+
+            usleep($waitUs);
         }
-        
-        $lastSendTime = microtime(true) * 1_000_000;
     }
 
     private function getEmailIdFromMetadata(array $metadata): ?int


### PR DESCRIPTION
## Summary                                                                                                                                                  
 I'm back with a bigger one 😄 — after migrating to a new server and wanting to make use of a higher SES rate limit, I noticed multiple Messenger consume workers weren't properly coordinated — each worker had its own process-local rate limiter, CommandPool fired all emails at once, and combined throughput spiked above the SES limit. On top of that, `processFailures()` throwing an exception caused Symfony Messenger to retry the entire message with all recipients, losing metadata during re-serialization and resulting in duplicate sends. Everything works well on my server, would kindly appreciate any feedback or testing from others!                                                                                            
                  
  ### Changes
  - Add shared file-based token bucket for cross-worker SES rate coordination (lock held ~30µs, not during API calls)
  - Micro-batch pacing: send `ceil(rate/10)`  emails at a time via CommandPool instead of firing all at once
  - Move rate limiting from between message payload building to between actual SES API calls — the original `throttle()` delay sat between `convertMessageToRawPayload()` calls, not between sends, so it had no effect on actual send timing
  - Inline retry with exponential backoff (1s, 2s, 4s) within doSend(), replacing Symfony Messenger retry
  - Fix `processFailures()` throwing exception — if 1 contact fails in a 700 recipient batch, the exception caused Messenger to retry the entire message with all 700 recipients, metadata lost during re-serialization → 700 duplicate sends
  - `getMaxBatchLimit()` now returns rate × batchmultiplier for configurable batch size
  - New DSN option: `batchmultiplier` (default 10) — controls how many contacts per queue message. 
  - Example: `ratelimit=70` × `batchmultiplier=10` = 700 contacts per message, meaning less queue overhead and smoother throughput
  ### Bugs fixed in original plugin
  - `processFailures()` throw → Messenger retry re-serializes envelope, metadata lost → duplicates to ALL recipients in the message batch.
  - `throttle()` was between payload building, not between actual SES API calls → no effective rate limiting
 - `CommandPool(concurrency=maxSendRate)` fired all emails at once with no delay between them → burst above SES limit, especially with multiple workers
  - No cross-worker rate coordination → each worker's rate limiter was process-local

### Recommended config
- Setting `messenger_retry_strategy_max_retries` to `0` in your Mautic config (`config/local.php`) is recommended as a safety net but not strictly required — the plugin now handles all retries inline with exponential backoff and no longer throws exceptions on partial failures, so Messenger retry should never trigger under normal operation.
- Set `ratelimit` in your SES DSN to match your actual SES account send rate limit. Setting it lower is fine — you'll just use less of your available throughput. Setting it higher than your actual limit will cause SES throttling errors. When scaling, simply update `ratelimit` to your new SES limit and add more workers (if needed) — the token bucket handles coordination automatically.
 
### Tested on
  - Mautic 7.0.1 
  - PHP 8.3.6
  - Ubuntu 24.04 / MariaDB 10.11.14
  - 4 Messenger workers via Supervisor
  - SES rate limit: 70/sec 

  ### Test results
  - 100,271 emails, 4 workers, 70/sec SES limit
  - 66.2 emails/sec sustained (94.6% utilization)
  - 0 duplicates, 0 failures, 29 bounces, 0 rejects
  - CloudWatch confirmed 4,200 mails/min at steady state
 
**SendRate utilization:**

  <img width="703" height="186" alt="Bildschirmfoto 2026-03-01 um 15 55 31"                                                                                   
  src="https://github.com/user-attachments/assets/d15fa2b9-8cb8-4413-a0cb-ea25b93c4084" />
                                                                                                                                                              
  **Emails sent:**                                          

  <img width="703" height="186" alt="Bildschirmfoto 2026-03-01 um 15 55 13" 
  src="https://github.com/user-attachments/assets/f168c31c-e5d2-4a7b-979e-bf100e8c51f7" />
