### PR TITLE
fix: cache SES clients per region for multi-region transports

### DIFF
--- a/Mailer/Factory/AmazonSesTransportFactory.php
+++ b/Mailer/Factory/AmazonSesTransportFactory.php
@@ -25,7 +25,8 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
 {
     const DEFAULT_RATE = 14;
 
-    private SesV2Client $amazonclient;
+    /** @var array<string, SesV2Client> Keyed by AWS region. */
+    private array $amazonClients = [];
     private TranslatorInterface $translator;
     private PathsHelper $pathsHelper;
     private EntityManagerInterface $entityManager;
@@ -177,13 +178,20 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
     /**
      * @return SesV2Client
      */
-    public function getAmazonClient(): SesV2Client
+    public function getAmazonClient(?string $region = null): SesV2Client
     {
-        if (!isset($this->amazonclient)) {
+        if ($region !== null) {
+            if (!isset($this->amazonClients[$region])) {
+                throw new IncompleteDsnException($this->translator->trans('mautic.amazonses.plugin.amazonclient.notset', [], 'validators'));
+            }
+            return $this->amazonClients[$region];
+        }
+
+        if (empty($this->amazonClients)) {
             throw new IncompleteDsnException($this->translator->trans('mautic.amazonses.plugin.amazonclient.notset', [], 'validators'));
         }
 
-        return $this->amazonclient;
+        return reset($this->amazonClients);
     }
 
     /**
@@ -219,7 +227,7 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
             throw new InvalidArgumentException($this->translator->trans('mautic.amazonses.plugin.ratelimit.invalid', [], 'validators'));
         }
 
-        if (!isset($this->amazonclient)) {
+        if (!isset($this->amazonClients[$dsn_region])) {
             $config = [
                 'version'     => 'latest',
                 'credentials' => CredentialProvider::fromCredentials(new Credentials($dsn_user, $dsn_password)),
@@ -231,10 +239,10 @@ class AmazonSesTransportFactory extends AbstractTransportFactory
                 $config['handler'] = $handler;
             }
 
-            $this->amazonclient = new SesV2Client($config);
+            $this->amazonClients[$dsn_region] = new SesV2Client($config);
         }
 
-        return $this->amazonclient;
+        return $this->amazonClients[$dsn_region];
     }
 
     /**


### PR DESCRIPTION
## Summary

- `AmazonSesTransportFactory` cached a single `SesV2Client` in `$this->amazonclient`. The first DSN's region locked in for the factory service's lifetime, so any later transport configured with a different region silently reused the first region's client.
- Replaced the single-client field with `array<string, SesV2Client>` keyed by region. Each DSN now resolves to its own client.
- `getAmazonClient()` accepts an optional `?string $region`; called without one it returns the first cached client to keep existing single-region callers working.

## Reproduction (pre-fix)

1. Configure two SES transports with different `?region=` options (e.g. one in `us-east-1`, one in `us-west-2`).
2. Send via the second transport (campaign send, or "Send test email" on the transport edit page).
3. Inspect the received message headers:
   - `X-SES-Outgoing` IP falls in the **first** region's outbound range
   - `Feedback-ID` shows `::1.us-east-1...` even when `us-west-2` was selected
   - `Received: from a*-*.smtp-out.amazonses.com` (us-east-1 MTA) instead of `a*-*.smtp-out.us-west-2.amazonses.com`

No exception, no log entry — fully silent.

## After the fix

Verified end-to-end on a Mautic 6 install. Sending via the `us-west-2` transport now produces:

- `Received: from a27-27.smtp-out.us-west-2.amazonses.com [54.240.27.27]`
- `Feedback-ID: ::1.us-west-2....:AmazonSES`
- `X-SES-Outgoing: <date>-54.240.27.27`
- `Return-Path: *@return-w.<sending-domain>` (us-west-2 bounce subdomain)

SPF / DKIM / DMARC all still PASS.

## Test plan

- [ ] Existing single-region installs: verify `getAmazonClient()` (no arg) still returns the cached client and `create($dsn)` still works.
- [ ] Multi-region installs: verify each configured transport hits its own SES region (check `X-SES-Outgoing` IP range or `Feedback-ID` region tag).
- [ ] `getAmazonClient($region)` for an uninitialized region throws `IncompleteDsnException` as before.