### PR TITLE
Fix per-email bounce attribution when SES omits headers

### DIFF
--- a/EventSubscriber/CallbackSubscriber.php
+++ b/EventSubscriber/CallbackSubscriber.php
@@ -20,6 +20,7 @@ use Mautic\LeadBundle\Entity\DoNotContact as DNC;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\DoNotContact as DncModel;
 use Mautic\LeadBundle\Model\LeadModel;
+use MauticPlugin\AmazonSesBundle\Helper\MauticEmailId;
 use MauticPlugin\AmazonSesBundle\Mailer\Transport\AmazonSesTransport;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -227,6 +228,7 @@ class CallbackSubscriber implements EventSubscriberInterface
                 $typeFound = true;
 
                 $emailId = $this->getEmailHeader($payload);
+                $this->logMissingEmailId('complaint', $payload, $emailId);
 
                 // Get bounced recipients in an array
                 $complaintRecipients = $payload['complaint']['complainedRecipients'];
@@ -282,6 +284,7 @@ class CallbackSubscriber implements EventSubscriberInterface
             $channel = 'soft_bounce';
         }
         $emailId = $this->getEmailHeader($payload);
+        $this->logMissingEmailId('bounce', $payload, $emailId);
         $bouncedRecipients = $payload['bounce']['bouncedRecipients'];
         foreach ($bouncedRecipients as $bouncedRecipient) {
             $bounceSubType = $payload['bounce']['bounceSubType'];
@@ -391,16 +394,26 @@ class CallbackSubscriber implements EventSubscriberInterface
         return preg_replace('/(.*)<(.*)>(.*)/s', '\2', $email);
     }
 
-    public function getEmailHeader($payload)
+    public function getEmailHeader(array $payload): ?int
     {
-        if (!isset($payload['mail']['headers'])) {
-            return null;
+        return MauticEmailId::fromSesNotification($payload);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function logMissingEmailId(string $notificationType, array $payload, ?int $emailId): void
+    {
+        if (null !== $emailId) {
+            return;
         }
 
-        foreach ($payload['mail']['headers'] as $header) {
-            if ('X-EMAIL-ID' === strtoupper($header['name'])) {
-                return $header['value'];
-            }
-        }
+        $this->logger?->warning(
+            'SES {notification_type} notification has no valid Mautic email ID; the contact will be updated, but per-email statistics cannot be attributed.',
+            [
+                'notification_type' => $notificationType,
+                'ses_message_id'    => $payload['mail']['messageId'] ?? null,
+            ]
+        );
     }
 }

--- a/Helper/MauticEmailId.php
+++ b/Helper/MauticEmailId.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\AmazonSesBundle\Helper;
+
+final class MauticEmailId
+{
+    public const HEADER_NAME = 'X-EMAIL-ID';
+
+    /**
+     * Add the Mautic email ID as an SES message tag.
+     *
+     * SES event-publishing notifications always expose message tags, while
+     * classic identity notifications expose custom headers only when original
+     * headers are enabled for that notification type.
+     *
+     * @param array<string, mixed> $payload
+     */
+    public static function addToSesPayload(array &$payload, mixed $value): void
+    {
+        $emailId = self::normalize($value);
+        if (null === $emailId) {
+            return;
+        }
+
+        foreach ($payload['EmailTags'] ?? [] as $index => $tag) {
+            if (is_array($tag) && 0 === strcasecmp((string) ($tag['Name'] ?? ''), self::HEADER_NAME)) {
+                $payload['EmailTags'][$index]['Value'] = (string) $emailId;
+
+                return;
+            }
+        }
+
+        $payload['EmailTags'][] = [
+            'Name'  => self::HEADER_NAME,
+            'Value' => (string) $emailId,
+        ];
+    }
+
+    /**
+     * Resolve the Mautic email ID from an SES notification.
+     *
+     * @param array<string, mixed> $payload
+     */
+    public static function fromSesNotification(array $payload): ?int
+    {
+        $mail = $payload['mail'] ?? null;
+        if (!is_array($mail)) {
+            return null;
+        }
+
+        foreach ($mail['headers'] ?? [] as $header) {
+            if (!is_array($header) || 0 !== strcasecmp((string) ($header['name'] ?? ''), self::HEADER_NAME)) {
+                continue;
+            }
+
+            $emailId = self::normalize($header['value'] ?? null);
+            if (null !== $emailId) {
+                return $emailId;
+            }
+        }
+
+        foreach ($mail['tags'] ?? [] as $name => $values) {
+            if (0 !== strcasecmp((string) $name, self::HEADER_NAME)) {
+                continue;
+            }
+
+            foreach (is_array($values) ? $values : [$values] as $value) {
+                $emailId = self::normalize($value);
+                if (null !== $emailId) {
+                    return $emailId;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function normalize(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (!is_string($value) || '' === $value || !ctype_digit($value)) {
+            return null;
+        }
+
+        $emailId = filter_var($value, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+        return false === $emailId ? null : $emailId;
+    }
+}

--- a/Mailer/Transport/AmazonSesTransport.php
+++ b/Mailer/Transport/AmazonSesTransport.php
@@ -20,6 +20,7 @@ use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use Mautic\EmailBundle\Mailer\Transport\TokenTransportInterface;
 use Mautic\EmailBundle\Mailer\Transport\TokenTransportTrait;
+use MauticPlugin\AmazonSesBundle\Helper\MauticEmailId;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
@@ -349,6 +350,12 @@ class AmazonSesTransport extends AbstractTransport implements TokenTransportInte
         $payload['ReplyToAddresses'] = $this->stringifyAddresses($this->setReplyTo($sentMessage));
 
         foreach ($sentMessage->getHeaders()->all() as $header) {
+            if (0 === strcasecmp($header->getName(), MauticEmailId::HEADER_NAME)) {
+                MauticEmailId::addToSesPayload($payload, $header->getBodyAsString());
+
+                continue;
+            }
+
             if ($header instanceof MetadataHeader) {
                 $payload['EmailTags'][] = ['Name' => $header->getKey(), 'Value' => $header->getValue()];
             } else {

--- a/README.MD
+++ b/README.MD
@@ -161,7 +161,8 @@ To receive feedback from Amazon SES regarding bounces and complaints, you need t
    ```
 
 4. Ensure your topic sends notifications for bounces, complaints, and delivery status.
-5. Test your callback configuration by sending test emails and reviewing Mautic logs to verify feedback is processed correctly.
+5. For classic identity-based SNS notifications, enable **Include original headers** for bounce and complaint notifications on the verified SES identity. Mautic uses the `X-EMAIL-ID` header to attribute feedback to the email statistics. Configuration-set event publishing can use the `X-EMAIL-ID` message tag added by this plugin instead.
+6. Test your callback configuration by sending test emails and reviewing Mautic logs to verify feedback is processed correctly.
 
 ---
 

--- a/Tests/Unit/Helper/MauticEmailIdTest.php
+++ b/Tests/Unit/Helper/MauticEmailIdTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\AmazonSesBundle\Tests\Unit\Helper;
+
+use MauticPlugin\AmazonSesBundle\Helper\MauticEmailId;
+use PHPUnit\Framework\TestCase;
+
+class MauticEmailIdTest extends TestCase
+{
+    public function testAddsEmailIdAsSesTag(): void
+    {
+        $payload = [];
+
+        MauticEmailId::addToSesPayload($payload, '42');
+
+        $this->assertSame([
+            ['Name' => 'X-EMAIL-ID', 'Value' => '42'],
+        ], $payload['EmailTags']);
+    }
+
+    public function testResolvesEmailIdFromOriginalHeader(): void
+    {
+        $payload = [
+            'mail' => [
+                'headers' => [
+                    ['name' => 'x-email-id', 'value' => '123'],
+                ],
+            ],
+        ];
+
+        $this->assertSame(123, MauticEmailId::fromSesNotification($payload));
+    }
+
+    public function testResolvesEmailIdFromEventPublishingTag(): void
+    {
+        $payload = [
+            'mail' => [
+                'tags' => [
+                    'X-EMAIL-ID' => ['456'],
+                ],
+            ],
+        ];
+
+        $this->assertSame(456, MauticEmailId::fromSesNotification($payload));
+    }
+
+    public function testFallsBackToTagWhenHeaderIsInvalid(): void
+    {
+        $payload = [
+            'mail' => [
+                'headers' => [
+                    ['name' => 'X-EMAIL-ID', 'value' => 'invalid'],
+                ],
+                'tags' => [
+                    'x-email-id' => ['789'],
+                ],
+            ],
+        ];
+
+        $this->assertSame(789, MauticEmailId::fromSesNotification($payload));
+    }
+
+    /**
+     * @dataProvider provideInvalidPayloads
+     */
+    public function testRejectsMissingOrInvalidEmailId(array $payload): void
+    {
+        $this->assertNull(MauticEmailId::fromSesNotification($payload));
+    }
+
+    public function provideInvalidPayloads(): array
+    {
+        return [
+            'missing mail object' => [[]],
+            'missing headers and tags' => [['mail' => []]],
+            'zero' => [['mail' => ['tags' => ['X-EMAIL-ID' => ['0']]]]],
+            'negative' => [['mail' => ['headers' => [['name' => 'X-EMAIL-ID', 'value' => '-1']]]]],
+            'non numeric' => [['mail' => ['headers' => [['name' => 'X-EMAIL-ID', 'value' => 'abc']]]]],
+        ];
+    }
+}

--- a/Tests/Unit/Mailer/Transport/AmazonSesTransportTest.php
+++ b/Tests/Unit/Mailer/Transport/AmazonSesTransportTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\AmazonSesBundle\Tests\Unit\Mailer\Transport;
 
+use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use MauticPlugin\AmazonSesBundle\Mailer\Transport\AmazonSesTransport;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -11,6 +12,29 @@ use Symfony\Component\Mailer\Exception\TransportException;
 
 class AmazonSesTransportTest extends TestCase
 {
+    public function testAddsMauticEmailIdToSesTags(): void
+    {
+        $reflection = new \ReflectionClass(AmazonSesTransport::class);
+        $transport = $reflection->newInstanceWithoutConstructor();
+        $message = (new MauticMessage())
+            ->from('sender@example.com')
+            ->to('recipient@example.com')
+            ->text('Test');
+        $message->getHeaders()->addTextHeader('X-EMAIL-ID', '42');
+
+        $messageProperty = $reflection->getProperty('message');
+        $messageProperty->setValue($transport, $message);
+
+        $payload = [];
+        $method = $reflection->getMethod('addSesHeaders');
+        $method->invokeArgs($transport, [&$payload, &$message, []]);
+
+        $this->assertContains(
+            ['Name' => 'X-EMAIL-ID', 'Value' => '42'],
+            $payload['EmailTags']
+        );
+    }
+
     public function testAcquireTokensThrowsTransportExceptionWhenBucketFileCannotBeOpened(): void
     {
         $reflection = new \ReflectionClass(AmazonSesTransport::class);


### PR DESCRIPTION
## Summary

This addresses a separate remaining case in current `main`. PR #47 fixed #46 by reading Mautic's `X-EMAIL-ID` from the original message headers, but the callback still depends exclusively on that header being present in the SES notification.

Classic SES identity notifications omit original headers unless **Include original headers** is enabled. Configuration-set event publishing exposes message tags instead. In either setup, when the callback payload has no original `X-EMAIL-ID` header, Mautic records the contact-level DNC entry without an email ID and per-email reports show zero bounces.

This change:

- copies a valid `X-EMAIL-ID` into SES `EmailTags` when sending;
- resolves callback attribution from either the original header or the event-publishing tag;
- validates IDs before using them and logs a clear warning when exact attribution is unavailable;
- documents the **Include original headers** requirement for classic identity-based SNS notifications;
- adds regression coverage for header, tag, fallback, invalid and missing ID payloads, plus transport tag creation.

The behavior introduced by #47 remains intact. Contact-level DNC processing is also preserved when an old or externally generated message has no usable ID.

## Existing data

This change intentionally does not rewrite existing DNC rows that were stored without an email ID. Historical attribution is instance-specific and is safe only where a unique email can be reconstructed from the contact's send history or retained SES data; ambiguous rows must remain unattributed.

## Verification

- `vendor/bin/phpunit --configuration phpunit.xml --fail-on-warning --testsuite=all`
  - 13 tests, 14 assertions, passing
- `composer validate --no-interaction --no-plugins --no-check-publish`
- PHP syntax checks for plugin and test sources

The existing repository CS script references a missing `.php-cs-fixer.php`, so that command cannot currently run from a clean checkout.
